### PR TITLE
Fix bug when compiling empty file with no -o flag

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -178,9 +178,13 @@ def main():
     # Report final status, if interesting
     fstatus = 'There were errors' if task_commit is None else task_commit.status
     if fstatus:
-        print('{}; {} not updated'.format(
-            fstatus, args.output or os.path.basename(task_latex.get_outname())
-            or 'output'))
+        output = args.output
+        if output is None:
+            if task_latex.get_outname() is not None:
+                output = os.path.basename(task_latex.get_outname())
+            else:
+                output = 'output'
+        print('{}; {} not updated'.format(fstatus, output))
     sys.exit(status)
 
 def arg_parser_shlex(string):

--- a/test/T-nooutput.sh
+++ b/test/T-nooutput.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+# Test running just latexrun empty.tex, where empty.tex produces no output.
+
+TMP=tmp.$(basename -s .sh $0)
+mkdir -p $TMP
+cat > $TMP/empty.tex <<EOF
+\documentclass{article}
+\begin{document}
+\end{document}
+EOF
+function clean() {
+    rm -rf $TMP
+}
+trap clean SIGINT SIGTERM
+
+# Intentionally use just the latexrun command to test when -o is not provided.
+"$1" "$TMP/empty.tex"
+
+clean
+
+## output:
+## No pages of output; output not updated


### PR DESCRIPTION
Compiling without -o on an empty LaTeX file would cause `os.path.basename` to get called on `None`, resulting in a stack trace.
