### PR TITLE
Emit a dependency file that makefiles can include.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,28 @@ Integrating with make
 =====================
 
 latexrun does its own dependency tracking (at a finer granularity than
-`make`).  Since it also does nothing if no dependencies have changed,
-it's easy to integrate with `make` using phony targets.  Here's a
-complete example:
+`make`), but also outputs a file listing dependencies in a format that
+`make` can understand, so it is easy to integrate with `make` using
+`include`. Here's a complete example:
 
 ```Makefile
-.PHONY: FORCE
-paper.pdf: FORCE {files that need to be generated, if any}
+-include latex.out/paper.pdf.d
+paper.pdf: {files that need to be generated, if any}
 	latexrun paper.tex
 
 .PHONY: clean
 clean:
 	latexrun --clean-all
+```
+
+If you want to take advantage of the finer grained dependency on
+tracking (on environment variables and the like), you can use phony
+targets (since latexrun does nothing if no dependencies have changed).
+
+```Makefile
+.PHONY: FORCE
+paper.pdf: FORCE {files that need to be generated, if any}
+	latexrun paper.tex
 ```
 
 Note that `paper.pdf` depends on a phony target, but is not itself
@@ -210,12 +220,6 @@ To do
 
 * Provide a way to disable output filters for things that do their own
   output parsing (e.g., AUCTeX).
-
-* Integrate even better with `make`.  Phony rules are okay, but will
-  force `make` dependencies to be generated even if latexrun
-  ultimately does nothing.  Since latexrun's dependencies are
-  finer-grained than `make`'s, it might be necessary to shell out to
-  latexrun to do this.
 
 * Separate clean data by source file so you can clean a single input
   file's outputs.

--- a/latexrun
+++ b/latexrun
@@ -171,6 +171,12 @@ def main():
             print('error: files are still changing after {} iterations; giving up'
                   .format(args.max_iterations), file=sys.stderr)
             status = max(status, 1)
+
+        # Generate a dep file for the makefile to include
+        if status == 0:
+            generate_dep_file(args.obj_dir,
+                              task_latex, task_bibtex, task_commit)
+
     except TaskError as e:
         print(str(e), file=sys.stderr)
         debug_exc()
@@ -229,6 +235,23 @@ def mkdir_p(path):
         if exc.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else: raise
+
+def generate_dep_file(obj_dir, task_latex, task_bibtex, task_commit):
+    try:
+        deps = task_latex.get_dep_filenames() + task_bibtex.get_dep_filenames()
+        target = task_commit.actual_output
+        # First, list the output as depending on everything
+        main_dep = "{}: {}\n".format(target, " ".join(deps))
+        # Then put an empty dependency in for everything else, so
+        # make doesn't get mad if a file is deleted.
+        empty_deps = "".join(dep + ":\n" for dep in deps)
+
+        dep_file = os.path.join(obj_dir, target + ".d")
+        with open(dep_file, 'w') as fp:
+            fp.write(main_dep + empty_deps)
+
+    except OSError as e:
+        raise TaskError('failed to build make dependency file: '+str(e)) from e
 
 class DB:
     """A latexrun control database."""
@@ -628,6 +651,13 @@ class Task:
             raise TaskError('error committing control database {}: {}'.format(
                 getattr(e, 'filename', '<unknown path>'), e)) from e
 
+    def get_dep_filenames(self):
+        """Collect the filenames of all file dependencies"""
+        last_summary = self.__db.get_summary(self.__task_id)
+        if not last_summary: return []
+        deps = last_summary['deps']
+        return [name for tag, dep, _ in deps if tag == 'file' for name in dep]
+
     def __make_summary(self, deps, run_result):
         """Construct a new task summary."""
         return {
@@ -996,6 +1026,7 @@ class LaTeXCommit(Task):
         self.__latex_task = latex_task
         self.__output_path = output_path
         self.status = 'There were errors'
+        self.actual_output = None
 
     def _input_latex(self):
         return self.__latex_task.get_status(), self.__latex_task.get_outname()
@@ -1029,6 +1060,7 @@ class LaTeXCommit(Task):
                 os.rename(outname + '~', commit)
         except OSError as e:
             raise TaskError('error committing latex output: {}'.format(e)) from e
+        self.actual_output = commit
         self._input('file', outname)
         self.status = None
         return RunResult([commit], None)


### PR DESCRIPTION
At the end of a build we output a dependency file in the object
directory containing a dependency list in make's format. We make no
effort to sort out the details of the dependencies: we just collect
all the file deps from the latex and bibtex tasks and make them
dependencies of the output pdf; the important thing is just that any
changes get detected so latex run is invoked, which will then figure
out the details.

If the output file is paper.pdf, we default to dumping the deps file
as latex.out/paper.pdf.d.
