### PR TITLE
Proper handling of line breaks

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -837,14 +837,14 @@ class LaTeX(Task):
         """
         jobname = outname = None
         for m in re.finditer(r'^Transcript written on "?(.*)\.log"?\.$', stdout,
-                             re.MULTILINE):
-            jobname = m.group(1)
+                             re.MULTILINE | re.DOTALL):
+            jobname = m.group(1).replace('\n', '')
         if jobname is None:
             print(stdout, file=sys.stderr)
             raise TaskError('failed to extract job name from latex log')
         for m in re.finditer(r'^Output written on "?(.*\.[^ ."]+)"? \([0-9]+ page',
-                             stdout, re.MULTILINE):
-            outname = m.group(1)
+                             stdout, re.MULTILINE | re.DOTALL):
+            outname = m.group(1).replace('\n', '')
         if outname is None and not \
            re.search(r'^No pages of output\.$|^! Emergency stop\.$'
                      r'|^!  ==> Fatal error occurred, no output PDF file produced!$',


### PR DESCRIPTION
With very long file names the latex output has line breaks, so the script fails

```output
...
(/usr/local/texlive/2014/texmf-dist/tex/latex/psnfss/ot1ppl.fd)
(/usr/local/texlive/2014/texmf-dist/tex/latex/psnfss/omlzplm.fd)
(/usr/local/texlive/2014/texmf-dist/tex/latex/psnfss/omszplm.fd)
(/usr/local/texlive/2014/texmf-dist/tex/latex/psnfss/omxzplm.fd)
(/usr/local/texlive/2014/texmf-dist/tex/latex/psnfss/ot1zplm.fd)
<Firma.jpg, id=1, 119.9682pt x 58.5387pt> <use Firma.jpg> <use Firma.jpg>
[1{/usr/local/texlive/2014/texmf-var/fonts/map/pdftex/updmap/pdftex.map} <./Fir
ma.jpg>] (latex.out/2015-06-23 - Mostafa Rutgers PSI-Jefferson Lab.aux) ){/usr/
local/texlive/2014/texmf-dist/fonts/enc/dvips/base/8r.enc}</usr/local/texlive/2
014/texmf-dist/fonts/type1/public/amsfonts/cm/cmsy10.pfb></usr/local/texlive/20
14/texmf-dist/fonts/type1/public/mathpazo/fplmri.pfb></usr/local/texlive/2014/t
exmf-dist/fonts/type1/urw/palatino/uplr8a.pfb></usr/local/texlive/2014/texmf-di
st/fonts/type1/urw/palatino/uplri8a.pfb>
Output written on "latex.out/2015-06-23 - Mostafa Rutgers PSI-Jefferson Lab.pdf
" (1 page, 48440 bytes).
Transcript written on "latex.out/2015-06-23 - Mostafa Rutgers PSI-Jefferson Lab
.log".

failed to extract job name from latex log
There were errors; output not updated
```

Changed the flags of the regex matching and clean up line breaks in the match.