### PR TITLE
Fix Okular not refreshing updated pdf.

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -1018,6 +1018,7 @@ class LaTeXCommit(Task):
                 debug('commiting {} to {}', outname, commit)
                 shutil.copy(outname, outname + '~')
                 os.rename(outname + '~', commit)
+                os.utime(commit)
         except OSError as e:
             raise TaskError('error committing latex output: {}'.format(e)) from e
         self._input('file', outname)


### PR DESCRIPTION
Okular (using KDE Frameworks 5) does not automatically reload if the pdf
is updated. This commit adds a `touch` in `LatexCommit._execute` if the
pdf has changed.

Using `os.utime` as it updates modification time. This means it still
works on filesystems mounted with `noatime`.

Note:
I do not know if other pdf viewers have the same problem and as Okular in KDE4 did not need this, it might just be a regression in Okular. Haven't had time to look into Okular itself yet.

Pull request in case other viewers have the same problem.
