### PR TITLE
Improved multiline detection

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -836,13 +836,13 @@ class LaTeX(Task):
         pages of output.
         """
         jobname = outname = None
-        for m in re.finditer(r'^Transcript written on "?(.*)\.log"?\.$', stdout,
+        for m in re.finditer(r'^Transcript written on "?(.*)\.l\n?o\n?g"?\.$', stdout,
                              re.MULTILINE | re.DOTALL):
             jobname = m.group(1).replace('\n', '')
         if jobname is None:
             print(stdout, file=sys.stderr)
             raise TaskError('failed to extract job name from latex log')
-        for m in re.finditer(r'^Output written on "?(.*\.[^ ."]+)"? \([0-9]+ page',
+        for m in re.finditer(r'^Output written on "?(.*\.[^ ."]+)"?[\n\s]+\([0-9]+ page',
                              stdout, re.MULTILINE | re.DOTALL):
             outname = m.group(1).replace('\n', '')
         if outname is None and not \


### PR DESCRIPTION
Handle cases in which:
- The extension is split in two lines
- The page number indicator is in a separate line
