### PR TITLE
XeLaTeX does not work well with bib file

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -517,7 +517,8 @@ def run_tasks(tasks, max_iterations):
         for task in tasks:
             if task.stable():
                 nstable += 1
-                if nstable == len(tasks):
+                if nstable == len(tasks)+1:
+                    task.run()
                     debug('fixed-point reached')
                     return True
             else:


### PR DESCRIPTION
XeLaTeX's behavior seems different from pdfLaTeX when we use a bib file.

So, when we build a tex file which contains a bib file with XeLaTeX, the output pdf file contains [?], while it does not with pdfLaTeX.

The following commands can reproduce this issue.

``` bash
./latexrun --clean-all && rm latex.out/ -rf
./latexrun --debug --latex-cmd=pdflatex test.tex
```

``` bash
./latexrun --clean-all && rm latex.out/ -rf
./latexrun --debug --latex-cmd=xelatex test.tex
```
- test.tex

``` tex
\documentclass{article}

\begin{document}

test\cite{bib-test}

\bibliographystyle{unsrt}
\bibliography{bib}

\end{document}
```
- bib.bib

``` bib
@Book{bib-test,
  author =    {hoge},
  title =        {fuga},
  publisher =    {piyo},
  year =         {2016},
}
```

I'm using ubuntu 14.04
- tex live : 2013
- pdfTeX : 3.1415926-2.5-1.40.14
- XeTeX : 3.1415926-2.5-0.9999.3-2014012222

This PR is one solution, but I don't think it's a good one...

How can I fix this issue?

Thanks,
