### PR TITLE
Fix parsing of {} in presence of nesting.

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -1292,9 +1292,16 @@ class LaTeXFilter:
         elif ch == '{':
             # TeX uses this for various things we want to ignore, like
             # file names and print_mark.  Consume up to the '}'
-            epos = self.__data.find('}', self.__pos)
+            epos = self.__pos
+            while True:
+                newpos = self.__data.find('}', epos) + 1
+                if '{' in self.__data[epos:newpos]:
+                    epos = newpos
+                else:
+                    epos = newpos
+                    break
             if epos != -1:
-                self.__pos = epos + 1
+                self.__pos = epos
             else:
                 self.__message('warning', None,
                                "unbalanced `{' in log; file names may be wrong")


### PR DESCRIPTION
Fixes #38, which is due to nested braces in the output, such as

```
Defining command \SIlist with sig. 'o>{\SplitList {;}}mm' on line 7290.
```

(I just noticed that #21 probably does this better...)
