### PR TITLE
Add a --query flag that lets make query if there is work to be done

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ Integrating with make
 =====================
 
 latexrun does its own dependency tracking (at a finer granularity than
-`make`).  Since it also does nothing if no dependencies have changed,
-it's easy to integrate with `make` using phony targets.  Here's a
-complete example:
+`make`). In order to facilitate integration with `make`, latexrun's
+`--query` command will check if there is work to be done and output
+a phony target to depend on if there is. Here's a complete example:
 
 ```Makefile
-.PHONY: FORCE
-paper.pdf: FORCE {files that need to be generated, if any}
+PAPER_DEP:=$(shell latexrun --query paper.tex)
+.PHONY: $(PAPER_DEP)
+paper.pdf: $(PAPER_DEP) {files that need to be generated, if any}
 	latexrun paper.tex
 
 .PHONY: clean
@@ -210,12 +211,6 @@ To do
 
 * Provide a way to disable output filters for things that do their own
   output parsing (e.g., AUCTeX).
-
-* Integrate even better with `make`.  Phony rules are okay, but will
-  force `make` dependencies to be generated even if latexrun
-  ultimately does nothing.  Since latexrun's dependencies are
-  finer-grained than `make`'s, it might be necessary to shell out to
-  latexrun to do this.
 
 * Separate clean data by source file so you can clean a single input
   file's outputs.

--- a/latexrun
+++ b/latexrun
@@ -99,6 +99,10 @@ def main():
     arg_parser.add_argument(
         '--debug', action='store_true',
         help='Enable detailed debug output')
+    arg_parser.add_argument(
+        '--query', action='store_true',
+        help='Query whether there is work to do (for make integration). '
+        'Outputs "FORCE" if yes, nothing if no.')
     actions = arg_parser.add_argument_group('actions')
     actions.add_argument(
         '--clean-all', action='store_true', help='Delete output files')
@@ -166,6 +170,10 @@ def main():
         task_bibtex = BibTeX(db, task_latex, args.bibtex_cmd, args.bibtex_args,
                              args.nowarns, args.obj_dir)
         tasks = [task_latex, task_commit, task_bibtex]
+        if args.query:
+            query_state([task_latex, task_bibtex])
+            sys.exit(0)
+
         stable = run_tasks(tasks, args.max_iterations)
 
         # Print final task output and gather exit status
@@ -197,6 +205,11 @@ def main():
         if Message._color:
             terminfo.send('sgr0')
     sys.exit(status)
+
+def query_state(tasks):
+    # If there is work to be done, output a phony target
+    if not all(t.stable() for t in tasks):
+        print('FORCE')
 
 def arg_parser_shlex(string):
     """Argument parser for shell token lists."""


### PR DESCRIPTION
A more correct and simpler (though probably slower) version of what I was going for in #20.

To facilitate make integration without running make rules unless there
is actual work to be done, we add a --query flag to latexrun that
outputs 'FORCE' when latexrun needs to be run. The Makefile can then
shell out to 'latexrun --query' and use the result as a dependency.