### PR TITLE
Fix _parse_jobname to handle intermediate font generation

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -861,15 +861,16 @@ class LaTeX(Task):
         pages of output.
         """
         jobname = outname = None
-        for m in re.finditer(r'^Transcript written on "?(.*)\.log"?\.$', stdout,
+        for m in re.finditer(r'^Transcript written on "?(.*?)\.log"?\.$', stdout,
                              re.MULTILINE | re.DOTALL):
             jobname = m.group(1).replace('\n', '')
         if jobname is None:
             print(stdout, file=sys.stderr)
             raise TaskError('failed to extract job name from latex log')
-        for m in re.finditer(r'^Output written on "?(.*\.[^ ."]+)"? \([0-9]+ page',
+        for m in re.finditer(r'^Output written on "?(.*?\.[^ ."]+)"? \([0-9]+ (page)?',
                              stdout, re.MULTILINE | re.DOTALL):
-            outname = m.group(1).replace('\n', '')
+            if m.group(2) == "page":
+                outname = m.group(1).replace('\n', '')
         if outname is None and not \
            re.search(r'^No pages of output\.$|^! Emergency stop\.$'
                      r'|^!  ==> Fatal error occurred, no output PDF file produced!$',


### PR DESCRIPTION
This patch fixes regexes in __parse_jobname to be non-greedy. Since there's a for-loop which iterates through the matches, greediness is not needed. 

This is enough to fix the jobname extraction. For the output, we'd like to skip all the "character" entries from font generation.

This fixes #46.