### PR TITLE
Make Latexrun work on Windows

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -833,6 +833,8 @@ class LaTeX(Task):
                 data = os.read(stdout.fileno(), 4096)
                 if not data:
                     break
+                if os.name == 'nt':
+                    data = data.replace(b'\r', b'')
                 # See "A note about encoding" above
                 data = data.decode('ascii', errors='surrogateescape')
                 buf.append(data)

--- a/latexrun
+++ b/latexrun
@@ -913,7 +913,7 @@ class LaTeX(Task):
             if parts[0] == 'PWD':
                 pwd = parts[1]
             elif parts[0] in ('INPUT', 'OUTPUT'):
-                if parts[1].startswith('/'):
+                if os.path.isabs(parts[1]):
                     path = parts[1]
                 else:
                     # Try to make "nice" paths, especially for clean
@@ -1685,7 +1685,7 @@ class BibTeX(Task):
                 # If this path is relative to the source directory,
                 # clean it up for error reporting and portability of
                 # the dependency DB
-                if filename.startswith('/'):
+                if os.path.isabs(filename):
                     relname = os.path.relpath(filename)
                     if '../' not in relname:
                         filename = relname

--- a/latexrun
+++ b/latexrun
@@ -279,7 +279,7 @@ class DB:
             json.dump(self.__val, fp, indent=2, separators=(',', ': '))
             fp.flush()
             os.fsync(fp.fileno())
-        os.rename(tmp_filename, self.__filename)
+        os.replace(tmp_filename, self.__filename)
 
     def get_summary(self, task_id):
         """Return the recorded summary for the given task or None."""
@@ -1044,7 +1044,7 @@ class LaTeXCommit(Task):
             else:
                 debug('commiting {} to {}', outname, commit)
                 shutil.copy(outname, outname + '~')
-                os.rename(outname + '~', commit)
+                os.replace(outname + '~', commit)
         except OSError as e:
             raise TaskError('error committing latex output: {}'.format(e)) from e
         self._input('file', outname)


### PR DESCRIPTION
These changes enabled me to use `latexrun` on Windows (with MikTeX). Just some minor fixes of path and stdout handling. At this point I can't guarantee that everything works as intended, but it seems to do the trick for now. I hope this helps someone out there!

In any case, thanks for putting `latexrun` out here. It's a very helpful utility :-)