### PR TITLE
Fix first-time compilation error involving biber

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -1629,7 +1629,7 @@ class BibTeX(Task):
 
         if self.__is_biber():
             outbase = os.path.join(cwd, outbase)
-        outputs = [outbase+ext for ext in ['.bbl','.blg','.bcf']
+        outputs = [outbase+ext for ext in ['.bbl','.blg','.bcf']]
         return RunResult(outputs, {'outbase': outbase, 'status': status,
                                    'inputs': inputs})
 

--- a/latexrun
+++ b/latexrun
@@ -1629,7 +1629,7 @@ class BibTeX(Task):
 
         if self.__is_biber():
             outbase = os.path.join(cwd, outbase)
-        outputs = [outbase + '.bbl', outbase + '.blg']
+        outputs = [outbase+ext for ext in ['.bbl','.blg','.bcf']
         return RunResult(outputs, {'outbase': outbase, 'status': status,
                                    'inputs': inputs})
 


### PR DESCRIPTION
I added '.bcf' to the outputs list - otherwise I was getting a 'malformed bcf' error the first time I ran latexrun on a file, with a biber backend.