### PR TITLE
Deal gracefully with multiple 'Transcript written on' lines.

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -861,7 +861,7 @@ class LaTeX(Task):
         pages of output.
         """
         jobname = outname = None
-        for m in re.finditer(r'^Transcript written on "?(.*)\.log"?\.$', stdout,
+        for m in re.finditer(r'^Transcript written on "?(.*?)\.log"?\.$', stdout,
                              re.MULTILINE | re.DOTALL):
             jobname = m.group(1).replace('\n', '')
         if jobname is None:


### PR DESCRIPTION
Whenever pdflatex is invoked on a clean copy of the texmf, it will first
invoke mktexfmt and various font conversion tools. These will also cause
pdflatex to print 'Transcript written on' lines for those steps.

The existing regular expression does greedy matching, meaning that the
full log output between the steps is parsed as the job name, causing
latexrun to attempt to open non-existent files.