### PR TITLE
Turn absolute paths in warnings/errors into relative ones.

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -457,10 +457,12 @@ class Message(collections.namedtuple(
         'Message', 'typ filename lineno msg')):
     def emit(self):
         if self.filename:
-            if self.filename.startswith('./'):
-                finfo = self.filename[2:]
-            else:
+            cwd = os.getcwd()
+            if (os.path.isabs(self.filename) and
+                os.path.commonpath([self.filename, cwd]) != cwd):
                 finfo = self.filename
+            else:
+                finfo = os.path.relpath(self.filename, cwd)
         else:
             finfo = '<no file>'
         if self.lineno is not None:


### PR DESCRIPTION
For [Bazel LaTeX](https://github.com/ProdriveTechnologies/bazel-latex), we store a copy of the texmf into the build
environment. The path of the build environment may be relatively long
and contain some randomness, depending on the build environment. Turn
such paths into relative ones, based on the current working directory to
make output more readable.