### PR TITLE
Refine the implementation of __clean_messages().

### DIFF
--- a/latexrun
+++ b/latexrun
@@ -979,7 +979,9 @@ class LaTeX(Task):
                 # Warnings on undefined references may occur in high
                 # numbers when documents fail to build.
                 continue
-            if msg.msg == 'There were undefined references':
+            if re.match(
+                r"There were (multiply-defined labels|undefined references)", msg.msg
+            ):
                 # LaTeX prints this at the end so the user knows it's
                 # worthwhile looking back at the log.  Since latexrun
                 # makes the earlier messages obvious, this is

--- a/latexrun
+++ b/latexrun
@@ -965,7 +965,7 @@ class LaTeX(Task):
 
     def __clean_messages(self, msgs):
         """Make some standard log messages more user-friendly."""
-        have_undefined_reference = False
+        has_errors = any(msg.typ == 'error' for msg in msgs)
         for msg in msgs:
             if msg.msg == '==> Fatal error occurred, no output PDF file produced!':
                 msg = msg._replace(typ='info',
@@ -973,10 +973,13 @@ class LaTeX(Task):
             if msg.msg.startswith('[LaTeX] '):
                 # Strip unnecessary package name
                 msg = msg._replace(msg=msg.msg.split(' ', 1)[1])
-            if re.match(r'Reference .* undefined', msg.msg):
-                have_undefined_reference = True
-            if have_undefined_reference and \
-               re.match(r'There were undefined references', msg.msg):
+            if has_errors and re.match(
+                r'.*[Rr]erun to get .* right|.* on page .* undefined', msg.msg
+            ):
+                # Warnings on undefined references may occur in high
+                # numbers when documents fail to build.
+                continue
+            if msg.msg == 'There were undefined references':
                 # LaTeX prints this at the end so the user knows it's
                 # worthwhile looking back at the log.  Since latexrun
                 # makes the earlier messages obvious, this is


### PR DESCRIPTION
- Suppress 'There were undefined references' unconditionally. The check
  that was done for it is inaccurate, as this message may also be
  printed when other types of things (citations, hyper references) are
  undefined. Even if we were to print it in corner cases, there would be
  nothing actionable.

- Swallow warnings containing 'Rerun to get X right' and regarding
  undefined references when there are errors. We tend to generate a lot
  of them upon error, even though they are likely a result of LaTeX not
  completing in the first place.